### PR TITLE
Call import() on CVSS::vX

### DIFF
--- a/lib/CVSS.pm
+++ b/lib/CVSS.pm
@@ -10,9 +10,9 @@ use Exporter qw(import);
 
 use constant DEBUG => $ENV{CVSS_DEBUG};
 
-use CVSS::v2 ();
-use CVSS::v3 ();
-use CVSS::v4 ();
+use CVSS::v2;
+use CVSS::v3;
+use CVSS::v4;
 
 our @EXPORT = qw(encode_cvss decode_cvss cvss_to_xml);
 


### PR DESCRIPTION
In order for the assessors that are dynamically created by CVSS::Base::import() to exist import must be called.  Fixes https://github.com/giterlizzi/perl-CVSS/issues/5