### PR TITLE
CVSS:v4 apply environmental modification before calculating the base score

### DIFF
--- a/lib/CVSS/v4.pm
+++ b/lib/CVSS/v4.pm
@@ -235,6 +235,11 @@ sub calculate_score {
     $self->metrics->{RE} //= 'X';
     $self->metrics->{U}  //= 'X';
 
+    # Apply environmental modifications, if any
+    for (@{$self->METRIC_GROUPS->{environmental}}) {
+        next unless /^M(..)/; # only MXX attributes for now
+        $self->metrics->{$1} = $self->metrics->{$_} unless ($self->metrics->{$_} eq 'X');
+    }
 
     # The following defines the index of each metric's values.
     # It is used when looking for the highest vector part of the


### PR DESCRIPTION
I'm really not sure if this is what should be done for V4, or whether it would be better to calculate the score multiple times I.e. base_score as is and environmental_score with the environmental overrides.  This is good enough for my purposes for now, but would understand if it's not what you want.  Partially fixes https://github.com/giterlizzi/perl-CVSS/issues/7